### PR TITLE
Ajout d'un tableau dans le readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,79 @@
 # aide-lautrenet
 Contenu statique de la documentation utilisateur de lautre.net
+
+## Correspondances des fichiers .md avec les pages du site
+
+| Fichier | Catégorie | Titre |
+| ---------- | ---------- | ---------- |
+| page1.md | 15. A propos | 02. AlternC |
+| page11.md | 04. Gestion d'un compte | 06. Configurer le gestionnaire de fichiers |
+| page12.md | 04. Gestion d'un compte | 07. Accès HTTPS / Certificats SSL |
+| page14.md | 05. Gestion messagerie | 02. Webmail et outil de messagerie |
+| page15.md | 05. Gestion bases de données | 01. Créer une base de données |
+| page16.md | 05. Gestion bases de données | 02. Utilisateurs MySQL |
+| page17.md | 05. Gestion bases de données | 03. phpMyAdmin |
+| page18.md | 07. Gestion listes de discussion | 01. Mailman gestionnaire de liste |
+| page19.md | 07. Gestion listes de discussion | 02. Créer une liste |
+| page2.md | 15. A propos | 03. Crédits |
+| page20.md | 07. Gestion listes de discussion | 04. Configurer la liste |
+| page21.md | 07. Gestion listes de discussion | 05. Gérer les abonnements |
+| page22.md | 07. Gestion listes de discussion | 06. Modifier les pages publiques |
+| page23.md | 07. Gestion listes de discussion | 07. Annexes |
+| page24.md | 07. Gestion listes de discussion | 04. Imposer son nom de liste |
+| page25.md | 07. Gestion listes de discussion | 08. Effacer un message des archives |
+| page26.md | 07. Gestion listes de discussion | Obtenir la liste des inscrits |
+| page27.md | 08. Gestion des statistiques | 01. Créer un jeu de statistiques |
+| page28.md | 08. Gestion des statistiques | 02. Les rubriques d'AWSTATS |
+| page29.md | 08. Gestion des statistiques | 03. Quand |
+| page3.md | 02. Interface | 01. Connexion |
+| page30.md | 08. Gestion des statistiques | 04. Qui |
+| page31.md | 08. Gestion des statistiques | 05. Navigation |
+| page32.md | 08. Gestion des statistiques | 06. Origine |
+| page33.md | 08. Gestion des statistiques | 07. Autres |
+| page34.md | 09. Administration des comptes AlternC | 01. Gestion des comptes |
+| page35.md | 09. Administration des comptes AlternC | 02. Panneau Administrateur |
+| page36.md | 09. Administration des comptes AlternC | 03. Admin SQL Général |
+| page37.md | 09. Administration des comptes AlternC | 04. Modifier les prérogatives de l'admin AlternC |
+| page38.md | 10. Accès sécurisé aux données (SSH et SFTP) | 01. Activer l'accès |
+| page39.md | 10. Accès sécurisé aux données (SSH et SFTP) | 02. Se connecter en SFTP |
+| page4.md | 02. Interface | 02. Prise en mains |
+| page40.md | 10. Accès sécurisé aux données (SSH et SFTP) | 03. Se connecter en SSH |
+| page41.md | 03. Administration d'un compte | 02. Obtenir une facture |
+| page42.md | 03. Administration d'un compte | 01. Payer sa cotisation |
+| page43.md | 03. Administration d'un compte | 03. Changer le nom de son compte |
+| page44.md | 03. Administration d'un compte | 04. Augmenter ses quotas |
+| page45.md | 03. Administration d'un compte | Les listes de l'association |
+| page46.md | 13. Diverses questions techniques | 10. Je dois faire une chmod 777 (ou un chmod 0) sur un dossier, comment faire ? |
+| page47.md | 13. Diverses questions techniques | 02. Quelle est l'architecture matérielle et logicielle de L'Autre Net ? |
+| page48.md | 13. Diverses questions techniques | 03. Est-il possible de désactiver le ''safe mode'' de PHP ? |
+| page49.md | 13. Diverses questions techniques | 04. Y'a-t-il une limitation de bande passante ou de trafic mensuel ? |
+| page5.md | 02. Interface | 03. FAQ Migration Juillet 2016 |
+| page50.md | 13. Diverses questions techniques | 05. Interdire le listage du contenu d'un répertoire |
+| page51.md | 13. Diverses questions techniques | 06. Interdire l'accès à un répertoire d'un site Web |
+| page52.md | 13. Diverses questions techniques | 07. Comment accéder aux pages en https de lautre.net avec Firefox 3 ? |
+| page53.md | 13. Diverses questions techniques | 08. Erreurs de session memcache |
+| page54.md | 13. Diverses questions techniques | 01. J'ai un problème auquel il n'est pas répondu |
+| page55.md | 13. Diverses questions techniques | 09. Comment connaître le chemin d'accès absolu à mon compte ? |
+| page56.md | 14. Installer des logiciels sur lautre.net | 01. La version X.Y du logiciel ZZZZ fonctionne-t-elle sur l'Autre net ? |
+| page57.md | 14. Installer des logiciels sur lautre.net | 02. Configuration de Joomla |
+| page58.md | 14. Installer des logiciels sur lautre.net | 03. Installation de Drupal |
+| page59.md | 14. Installer des logiciels sur lautre.net | 04. Les plugins de Spip ne fonctionnent pas ! |
+| page6.md | 04. Gestion d'un compte | 02. Répertoires et fichiers |
+| page60.md | 14. Installer des logiciels sur lautre.net | 05. Configuration de Dotclear2 |
+| page61.md | 14. Installer des logiciels sur lautre.net | 06. Configuration de Moodle |
+| page62.md | 14. Installer des logiciels sur lautre.net | 07. Configuration de PHP MyBibli « PMB » |
+| page63.md | 14. Installer des logiciels sur lautre.net | 08. Installer Spip et un nom de domaine |
+| page64.md | 14. Installer des logiciels sur lautre.net | 09. Problèmes sur dokuwiki |
+| page65.md | 14. Installer des logiciels sur lautre.net | 10. Installation et configuration de wordpress sur lautre.net |
+| page66.md | 11. Sur les bases de données MySQL | 01. Comment utiliser ma base de données MySQL ? |
+| page67.md | 11. Sur les bases de données MySQL | 02. Comment sauvegarder ma base de données SQL? |
+| page68.md | 11. Sur les bases de données MySQL | 03. Mon site n'arrive pas à se connecter à la base de données Mysql ! |
+| page69.md | 11. Sur les bases de données MySQL | 04. Comment télécharger ma base de données SQL ? |
+| page7.md | 04. Gestion d'un compte | 01. Nom de domaine |
+| page70.md | 12. Sur les services web | 01. Mon logiciel a besoin d'afficher un fichier commençant par un point, et rien ne s'affiche. Pourquoi ? |
+| page71.md | 01. Bienvenue | Bienvenue à l'Autre Net |
+| page72.md | 16. Quand plus rien me fonctionne? | Et quand plus rien ne marche? |
+| page8.md | 04. Gestion d'un compte | 03. Gérer domaine et sous-domaine |
+| page9.md | 04. Gestion d'un compte | 04. Import de fichiers et FTP |
+| page10.md | 04. Gestion d'un compte | 05. Protéger un répertoire |
+| page13.md | 05. Gestion messagerie | 01. Mails et alias | 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Contenu statique de la documentation utilisateur de lautre.net
 
 ## Correspondances des fichiers .md avec les pages du site
 
-| Catégorie | Titre | Fichier
+| Catégorie | Titre | Fichier |
 | ---------- | ---------- | ---------- |
 | 01. Bienvenue | Bienvenue à l'Autre Net | page71.md |
 | 02. Interface | 01. Connexion | page3.md |

--- a/README.md
+++ b/README.md
@@ -3,77 +3,77 @@ Contenu statique de la documentation utilisateur de lautre.net
 
 ## Correspondances des fichiers .md avec les pages du site
 
-| Fichier | Catégorie | Titre |
+| Catégorie | Titre | Fichier
 | ---------- | ---------- | ---------- |
-| page1.md | 15. A propos | 02. AlternC |
-| page11.md | 04. Gestion d'un compte | 06. Configurer le gestionnaire de fichiers |
-| page12.md | 04. Gestion d'un compte | 07. Accès HTTPS / Certificats SSL |
-| page14.md | 05. Gestion messagerie | 02. Webmail et outil de messagerie |
-| page15.md | 05. Gestion bases de données | 01. Créer une base de données |
-| page16.md | 05. Gestion bases de données | 02. Utilisateurs MySQL |
-| page17.md | 05. Gestion bases de données | 03. phpMyAdmin |
-| page18.md | 07. Gestion listes de discussion | 01. Mailman gestionnaire de liste |
-| page19.md | 07. Gestion listes de discussion | 02. Créer une liste |
-| page2.md | 15. A propos | 03. Crédits |
-| page20.md | 07. Gestion listes de discussion | 04. Configurer la liste |
-| page21.md | 07. Gestion listes de discussion | 05. Gérer les abonnements |
-| page22.md | 07. Gestion listes de discussion | 06. Modifier les pages publiques |
-| page23.md | 07. Gestion listes de discussion | 07. Annexes |
-| page24.md | 07. Gestion listes de discussion | 04. Imposer son nom de liste |
-| page25.md | 07. Gestion listes de discussion | 08. Effacer un message des archives |
-| page26.md | 07. Gestion listes de discussion | Obtenir la liste des inscrits |
-| page27.md | 08. Gestion des statistiques | 01. Créer un jeu de statistiques |
-| page28.md | 08. Gestion des statistiques | 02. Les rubriques d'AWSTATS |
-| page29.md | 08. Gestion des statistiques | 03. Quand |
-| page3.md | 02. Interface | 01. Connexion |
-| page30.md | 08. Gestion des statistiques | 04. Qui |
-| page31.md | 08. Gestion des statistiques | 05. Navigation |
-| page32.md | 08. Gestion des statistiques | 06. Origine |
-| page33.md | 08. Gestion des statistiques | 07. Autres |
-| page34.md | 09. Administration des comptes AlternC | 01. Gestion des comptes |
-| page35.md | 09. Administration des comptes AlternC | 02. Panneau Administrateur |
-| page36.md | 09. Administration des comptes AlternC | 03. Admin SQL Général |
-| page37.md | 09. Administration des comptes AlternC | 04. Modifier les prérogatives de l'admin AlternC |
-| page38.md | 10. Accès sécurisé aux données (SSH et SFTP) | 01. Activer l'accès |
-| page39.md | 10. Accès sécurisé aux données (SSH et SFTP) | 02. Se connecter en SFTP |
-| page4.md | 02. Interface | 02. Prise en mains |
-| page40.md | 10. Accès sécurisé aux données (SSH et SFTP) | 03. Se connecter en SSH |
-| page41.md | 03. Administration d'un compte | 02. Obtenir une facture |
-| page42.md | 03. Administration d'un compte | 01. Payer sa cotisation |
-| page43.md | 03. Administration d'un compte | 03. Changer le nom de son compte |
-| page44.md | 03. Administration d'un compte | 04. Augmenter ses quotas |
-| page45.md | 03. Administration d'un compte | Les listes de l'association |
-| page46.md | 13. Diverses questions techniques | 10. Je dois faire une chmod 777 (ou un chmod 0) sur un dossier, comment faire ? |
-| page47.md | 13. Diverses questions techniques | 02. Quelle est l'architecture matérielle et logicielle de L'Autre Net ? |
-| page48.md | 13. Diverses questions techniques | 03. Est-il possible de désactiver le ''safe mode'' de PHP ? |
-| page49.md | 13. Diverses questions techniques | 04. Y'a-t-il une limitation de bande passante ou de trafic mensuel ? |
-| page5.md | 02. Interface | 03. FAQ Migration Juillet 2016 |
-| page50.md | 13. Diverses questions techniques | 05. Interdire le listage du contenu d'un répertoire |
-| page51.md | 13. Diverses questions techniques | 06. Interdire l'accès à un répertoire d'un site Web |
-| page52.md | 13. Diverses questions techniques | 07. Comment accéder aux pages en https de lautre.net avec Firefox 3 ? |
-| page53.md | 13. Diverses questions techniques | 08. Erreurs de session memcache |
-| page54.md | 13. Diverses questions techniques | 01. J'ai un problème auquel il n'est pas répondu |
-| page55.md | 13. Diverses questions techniques | 09. Comment connaître le chemin d'accès absolu à mon compte ? |
-| page56.md | 14. Installer des logiciels sur lautre.net | 01. La version X.Y du logiciel ZZZZ fonctionne-t-elle sur l'Autre net ? |
-| page57.md | 14. Installer des logiciels sur lautre.net | 02. Configuration de Joomla |
-| page58.md | 14. Installer des logiciels sur lautre.net | 03. Installation de Drupal |
-| page59.md | 14. Installer des logiciels sur lautre.net | 04. Les plugins de Spip ne fonctionnent pas ! |
-| page6.md | 04. Gestion d'un compte | 02. Répertoires et fichiers |
-| page60.md | 14. Installer des logiciels sur lautre.net | 05. Configuration de Dotclear2 |
-| page61.md | 14. Installer des logiciels sur lautre.net | 06. Configuration de Moodle |
-| page62.md | 14. Installer des logiciels sur lautre.net | 07. Configuration de PHP MyBibli « PMB » |
-| page63.md | 14. Installer des logiciels sur lautre.net | 08. Installer Spip et un nom de domaine |
-| page64.md | 14. Installer des logiciels sur lautre.net | 09. Problèmes sur dokuwiki |
-| page65.md | 14. Installer des logiciels sur lautre.net | 10. Installation et configuration de wordpress sur lautre.net |
-| page66.md | 11. Sur les bases de données MySQL | 01. Comment utiliser ma base de données MySQL ? |
-| page67.md | 11. Sur les bases de données MySQL | 02. Comment sauvegarder ma base de données SQL? |
-| page68.md | 11. Sur les bases de données MySQL | 03. Mon site n'arrive pas à se connecter à la base de données Mysql ! |
-| page69.md | 11. Sur les bases de données MySQL | 04. Comment télécharger ma base de données SQL ? |
-| page7.md | 04. Gestion d'un compte | 01. Nom de domaine |
-| page70.md | 12. Sur les services web | 01. Mon logiciel a besoin d'afficher un fichier commençant par un point, et rien ne s'affiche. Pourquoi ? |
-| page71.md | 01. Bienvenue | Bienvenue à l'Autre Net |
-| page72.md | 16. Quand plus rien me fonctionne? | Et quand plus rien ne marche? |
-| page8.md | 04. Gestion d'un compte | 03. Gérer domaine et sous-domaine |
-| page9.md | 04. Gestion d'un compte | 04. Import de fichiers et FTP |
-| page10.md | 04. Gestion d'un compte | 05. Protéger un répertoire |
-| page13.md | 05. Gestion messagerie | 01. Mails et alias | 
+| 01. Bienvenue | Bienvenue à l'Autre Net | page71.md |
+| 02. Interface | 01. Connexion | page3.md |
+| 02. Interface | 02. Prise en mains | page4.md |
+| 02. Interface | 03. FAQ Migration Juillet 2016 | page5.md |
+| 03. Administration d'un compte | 01. Payer sa cotisation | page42.md |
+| 03. Administration d'un compte | 02. Obtenir une facture | page41.md |
+| 03. Administration d'un compte | 03. Changer le nom de son compte | page43.md |
+| 03. Administration d'un compte | 04. Augmenter ses quotas | page44.md |
+| 03. Administration d'un compte | Les listes de l'association | page45.md |
+| 04. Gestion d'un compte | 01. Nom de domaine | page7.md |
+| 04. Gestion d'un compte | 02. Répertoires et fichiers | page6.md |
+| 04. Gestion d'un compte | 03. Gérer domaine et sous-domaine | page8.md |
+| 04. Gestion d'un compte | 04. Import de fichiers et FTP | page9.md |
+| 04. Gestion d'un compte | 05. Protéger un répertoire | page10.md |
+| 04. Gestion d'un compte | 06. Configurer le gestionnaire de fichiers | page11.md |
+| 04. Gestion d'un compte | 07. Accès HTTPS / Certificats SSL | page12.md |
+| 05. Gestion bases de données | 01. Créer une base de données | page15.md |
+| 05. Gestion bases de données | 02. Utilisateurs MySQL | page16.md |
+| 05. Gestion bases de données | 03. phpMyAdmin | page17.md |
+| 06. Gestion messagerie | 01. Mails et alias | page13.md |
+| 06. Gestion messagerie | 02. Webmail et outil de messagerie | page14.md |
+| 07. Gestion listes de discussion | 01. Mailman gestionnaire de liste | page18.md |
+| 07. Gestion listes de discussion | 02. Créer une liste | page19.md |
+| 07. Gestion listes de discussion | 04. Configurer la liste | page20.md |
+| 07. Gestion listes de discussion | 04. Imposer son nom de liste | page24.md |
+| 07. Gestion listes de discussion | 05. Gérer les abonnements | page21.md |
+| 07. Gestion listes de discussion | 06. Modifier les pages publiques | page22.md |
+| 07. Gestion listes de discussion | 07. Annexes | page23.md |
+| 07. Gestion listes de discussion | 08. Effacer un message des archives | page25.md |
+| 07. Gestion listes de discussion | Obtenir la liste des inscrits | page26.md |
+| 08. Gestion des statistiques | 01. Créer un jeu de statistiques | page27.md |
+| 08. Gestion des statistiques | 02. Les rubriques d'AWSTATS | page28.md |
+| 08. Gestion des statistiques | 03. Quand | page29.md |
+| 08. Gestion des statistiques | 04. Qui | page30.md |
+| 08. Gestion des statistiques | 05. Navigation | page31.md |
+| 08. Gestion des statistiques | 06. Origine | page32.md |
+| 08. Gestion des statistiques | 07. Autres | page33.md |
+| 09. Administration des comptes AlternC | 01. Gestion des comptes | page34.md |
+| 09. Administration des comptes AlternC | 02. Panneau Administrateur | page35.md |
+| 09. Administration des comptes AlternC | 03. Admin SQL Général | page36.md |
+| 09. Administration des comptes AlternC | 04. Modifier les prérogatives de l'admin AlternC | page37.md |
+| 10. Accès sécurisé aux données (SSH et SFTP) | 01. Activer l'accès | page38.md |
+| 10. Accès sécurisé aux données (SSH et SFTP) | 02. Se connecter en SFTP | page39.md |
+| 10. Accès sécurisé aux données (SSH et SFTP) | 03. Se connecter en SSH | page40.md |
+| 11. Sur les bases de données MySQL | 01. Comment utiliser ma base de données MySQL ? | page66.md |
+| 11. Sur les bases de données MySQL | 02. Comment sauvegarder ma base de données SQL? | page67.md |
+| 11. Sur les bases de données MySQL | 03. Mon site n'arrive pas à se connecter à la base de données Mysql ! | page68.md |
+| 11. Sur les bases de données MySQL | 04. Comment télécharger ma base de données SQL ? | page69.md |
+| 12. Sur les services web | 01. Mon logiciel a besoin d'afficher un fichier commençant par un point, et rien ne s'affiche. Pourquoi ? | page70.md |
+| 13. Diverses questions techniques | 01. J'ai un problème auquel il n'est pas répondu | page54.md |
+| 13. Diverses questions techniques | 02. Quelle est l'architecture matérielle et logicielle de L'Autre Net ? | page47.md |
+| 13. Diverses questions techniques | 03. Est-il possible de désactiver le ''safe mode'' de PHP ? | page48.md |
+| 13. Diverses questions techniques | 04. Y'a-t-il une limitation de bande passante ou de trafic mensuel ? | page49.md |
+| 13. Diverses questions techniques | 05. Interdire le listage du contenu d'un répertoire | page50.md |
+| 13. Diverses questions techniques | 06. Interdire l'accès à un répertoire d'un site Web | page51.md |
+| 13. Diverses questions techniques | 07. Comment accéder aux pages en https de lautre.net avec Firefox 3 ? | page52.md |
+| 13. Diverses questions techniques | 08. Erreurs de session memcache | page53.md |
+| 13. Diverses questions techniques | 09. Comment connaître le chemin d'accès absolu à mon compte ? | page55.md |
+| 13. Diverses questions techniques | 10. Je dois faire une chmod 777 (ou un chmod 0) sur un dossier, comment faire ? | page46.md |
+| 14. Installer des logiciels sur lautre.net | 01. La version X.Y du logiciel ZZZZ fonctionne-t-elle sur l'Autre net ? | page56.md |
+| 14. Installer des logiciels sur lautre.net | 02. Configuration de Joomla | page57.md |
+| 14. Installer des logiciels sur lautre.net | 03. Installation de Drupal | page58.md |
+| 14. Installer des logiciels sur lautre.net | 04. Les plugins de Spip ne fonctionnent pas ! | page59.md |
+| 14. Installer des logiciels sur lautre.net | 05. Configuration de Dotclear2 | page60.md |
+| 14. Installer des logiciels sur lautre.net | 06. Configuration de Moodle | page61.md |
+| 14. Installer des logiciels sur lautre.net | 07. Configuration de PHP MyBibli « PMB » | page62.md |
+| 14. Installer des logiciels sur lautre.net | 08. Installer Spip et un nom de domaine | page63.md |
+| 14. Installer des logiciels sur lautre.net | 09. Problèmes sur dokuwiki | page64.md |
+| 14. Installer des logiciels sur lautre.net | 10. Installation et configuration de wordpress sur lautre.net | page65.md |
+| 15. A propos | 02. AlternC | page1.md |
+| 15. A propos | 03. Crédits | page2.md |
+| 16. Quand plus rien me fonctionne? | Et quand plus rien ne marche? | page72.md |

--- a/content/page13.md
+++ b/content/page13.md
@@ -1,6 +1,6 @@
 Title: 01. Mails et alias 
 Date: 2010-09-03 11:41:51
-Category: 05. Gestion messagerie
+Category: 06. Gestion messagerie
 Tags: old
 Summary: Comment créer Mails et alias de manière aisée depuis le bureau virtuel d'AlternC. . Dans cette section, nous allons décrire la gestion du courrier électronique.
 

--- a/content/page14.md
+++ b/content/page14.md
@@ -1,6 +1,6 @@
 Title: 02. Webmail et outil de messagerie 
 Date: 2009-03-08 19:35:56
-Category: 05. Gestion messagerie
+Category: 06. Gestion messagerie
 Tags: old
 Summary: Comment accéder à votre messagerie, soit en ligne par webmail sécurisé, soit depuis votre logiciel de mail, sur votre ordinateur. . AlternC vous offre également la possibilité de consulter vos mails en ligne depuis le webmail sécurisé .
 


### PR DESCRIPTION
Pour s'y retrouver plus facilement, ajout d'un tableau des correspondances entre les fichiers .md et les pages du site dans le readme.
Il est trié par catégories,titre.

J'ai également modifier le numéro de la catégorie Gestion messagerie qui était en doublon avec Gestion Base de données.